### PR TITLE
Add GitHub Actions workflow for abapgit format validation

### DIFF
--- a/.github/workflows/abapgit_format.yaml
+++ b/.github/workflows/abapgit_format.yaml
@@ -1,0 +1,59 @@
+name: abapgit_format
+
+on:
+  push:
+    branches: [standard]
+    paths:
+      - 'src/**/*.wapa.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  abapgit_format:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: standard
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pad WAPA files to 255-char lines (abapgit format)
+        run: |
+          python3 <<'PY'
+          from pathlib import Path
+
+          WIDTH = 255
+          changed = []
+          for path in sorted(Path('src').rglob('*.wapa.*.*')):
+              if not path.is_file():
+                  continue
+              original = path.read_bytes()
+              text = original.replace(b'\r\n', b'\n')
+              if text.endswith(b'\n'):
+                  text = text[:-1]
+              lines = text.split(b'\n')
+              padded = [line.ljust(WIDTH, b' ') for line in lines]
+              out = b'\n'.join(padded)
+              if out != original:
+                  path.write_bytes(out)
+                  changed.append(str(path))
+
+          for c in changed:
+              print(f"reformatted: {c}")
+          print(f"total: {len(changed)} file(s) reformatted")
+          PY
+
+      - name: Commit and push if changed
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "no formatting changes — nothing to commit"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m "chore: fix abapgit formatting [skip ci]"
+          git push origin standard


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub Actions workflow that automatically formats WAPA files to comply with abapgit standards by padding lines to 255 characters.

## Key Changes
- Added `.github/workflows/abapgit_format.yaml` workflow that:
  - Triggers on pushes to the `standard` branch when WAPA files are modified
  - Runs a Python script to pad all lines in `*.wapa.*.*` files to 255 characters
  - Normalizes line endings (converts CRLF to LF)
  - Automatically commits and pushes formatting changes back to the repository
  - Skips execution when triggered by the bot itself to prevent infinite loops

## Implementation Details
- The workflow uses a Python script embedded in the workflow file to process WAPA files
- Line padding is done with trailing spaces to maintain the 255-character width required by abapgit
- Changes are committed with a `[skip ci]` tag to prevent recursive workflow triggers
- The workflow only runs when the actor is not `github-actions[bot]` to avoid automation loops
- Requires `contents: write` permission to commit and push changes

https://claude.ai/code/session_01YFCTto72XqoKZgpGWpx8pQ