### PR TITLE
Add legacy-free (UI5 2.0) build generation tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 downport
 node_modules
 output
+
+legacy_free/out/
+lf_cloud/

--- a/legacy_free/README.md
+++ b/legacy_free/README.md
@@ -1,0 +1,34 @@
+# legacy_free
+
+Generates the **legacy-free (UI5 2.0) variant** of this frontend, taking the
+classic webapp coding over **1:1** and adapting only the bootstrap layer so it
+runs on the legacy-free OpenUI5 build.
+
+```
+cloud/app/webapp ──▶ patchIndexHtml + patchManifest ──▶ .github/app2bsp ──▶ bsp_rename(Z2UI5_V2) ──▶ src/
+```
+
+The result is published to the [`frontend-legacy-free`](https://github.com/abap2UI5/frontend-legacy-free) repo.
+
+## Run
+
+```bash
+npm run build_legacy_free      # -> legacy_free/out/src
+```
+
+This clones the `cloud` webapp, applies the bootstrap patch and reuses the
+existing `.github/app2bsp` + `bsp_rename` tooling. Nothing else is touched.
+
+## The only adaptations (everything else is 1:1)
+
+| File | Change | Why |
+| --- | --- | --- |
+| `index.html` | load `1.142.0-legacy-free` SDK (CDN); 2.x config attributes `resource-roots` / `on-init` / `compat-version` / `frame-options`; `preconnect`; `libs=sap.m` | bootstrap the legacy-free build |
+| `manifest.json` | `minUI5Version 1.136.0`, `_version 2.0.0` | legacy-free starts at 1.136 |
+
+Deployment identity is renamed to `Z2UI5_V2` (parallel install). Backend handler
+is shared (`/sap/bc/z2ui5`) by default; pass `--own-backend` for an isolated one.
+
+> The classic frontend JS is already forward-compatible (no jQuery.sap, no
+> sync APIs, guarded `getCore()` fallbacks) — so no code changes are needed,
+> only the bootstrap.

--- a/legacy_free/build-legacy-free.mjs
+++ b/legacy_free/build-legacy-free.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// build-legacy-free.mjs
+// Erzeugt den legacy-free (UI5 2.0) BSP-Stand 1:1 aus dem klassischen
+// abap2UI5-Frontend (cloud/app/webapp) + minimalem Bootstrap-Patch.
+//
+//   cloud/app/webapp -> [Bootstrap-Patch] -> app2bsp/run.js -> bsp_rename(Z2UI5_V2)
+//
+// Nur index.html + manifest.json werden angepasst (alles andere bleibt 1:1).
+// Aufruf:  node build-legacy-free.mjs <frontend-repo> <cloud-webapp> <out-dir> [--own-backend]
+
+import { execFileSync } from "node:child_process";
+import { cpSync, rmSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const [frontendRepo, cloudWebapp, outDir] = process.argv.slice(2);
+const ownBackend = process.argv.includes("--own-backend");
+const SDK = "https://sdk.openui5.org/1.142.0-legacy-free/resources/sap-ui-core.js";
+const BSP_WIDTH = 255;
+
+// --- der einzige inhaltliche Eingriff: Bootstrap auf legacy-free umstellen ---
+function patchIndexHtml(s) {
+  return s
+    .replace(/^\s*<meta http-equiv="X-UA-Compatible"[^>]*>\n/m, "")
+    .replace(/(<title>abap2UI5<\/title>\n)/,
+      `$1\n    <link rel="preconnect" href="https://sdk.openui5.org" crossorigin>\n    <link rel="dns-prefetch" href="https://sdk.openui5.org">\n`)
+    .replace(/src="resources\/sap-ui-core\.js"/, `src="${SDK}"`)
+    .replace(/data-sap-ui-resourceroots=/, "data-sap-ui-resource-roots=")
+    .replace(/data-sap-ui-oninit=/, "data-sap-ui-on-init=")
+    .replace(/data-sap-ui-compatVersion=/, "data-sap-ui-compat-version=")
+    .replace(/(data-sap-ui-frameOptions="trusted")/, `data-sap-ui-frame-options="trusted"\n        data-sap-ui-libs="sap.m"`);
+}
+function patchManifest(s) {
+  return s
+    .replace(/"_version":\s*"1\.65\.0"/, '"_version": "2.0.0"')
+    .replace(/"minUI5Version":\s*"1\.71\.0"/, '"minUI5Version": "1.136.0"');
+}
+
+// BSP-Page-Format (255-Zeichen-Zeilen, kein Schluss-Newline) – wie app2bsp
+function rePad(line) { return line.length <= BSP_WIDTH ? line.padEnd(BSP_WIDTH)
+  : line.match(new RegExp(`.{1,${BSP_WIDTH}}`, "g")).map(x => x.padEnd(BSP_WIDTH)).join("\n"); }
+
+const work = join(outDir, "_work");
+rmSync(outDir, { recursive: true, force: true }); mkdirSync(work, { recursive: true });
+
+// 1) Tooling + saubere cloud-Webapp bereitstellen
+cpSync(join(frontendRepo, ".github"), join(work, ".github"), { recursive: true });
+cpSync(join(frontendRepo, "bsp_rename"), join(work, "bsp_rename"), { recursive: true });
+cpSync(cloudWebapp, join(work, "frontend/app/webapp"), { recursive: true });
+
+// 2) Bootstrap-Patch
+const wa = join(work, "frontend/app/webapp");
+writeFileSync(join(wa, "index.html"), patchIndexHtml(readFileSync(join(wa, "index.html"), "utf8")));
+writeFileSync(join(wa, "manifest.json"), patchManifest(readFileSync(join(wa, "manifest.json"), "utf8")));
+
+// 3) app2bsp  +  4) rename auf Z2UI5_V2
+execFileSync("node", [".github/app2bsp/run.js"], { cwd: work, stdio: "ignore" });
+execFileSync("node", ["bsp_rename/rename-bsp.mjs", "Z2UI5_V2", "--dir", "src/02", "--yes"], { cwd: work, stdio: "ignore" });
+
+// 5) Backend-Datasource: default geteilt (/sap/bc/z2ui5), --own-backend = /sap/bc/z2ui5_v2
+const bsp = join(work, "src/02");
+if (!ownBackend) {
+  const mf = join(bsp, "z2ui5_v2.wapa.manifest.json");
+  const fixed = readFileSync(mf, "utf8").split("\n")
+    .map(l => l.includes('"/sap/bc/z2ui5_v2"') ? rePad(l.replace(/ *$/, "").replace("/sap/bc/z2ui5_v2", "/sap/bc/z2ui5")) : l)
+    .join("\n");
+  writeFileSync(mf, fixed);
+}
+
+cpSync(bsp, join(outDir, "src"), { recursive: true });
+rmSync(work, { recursive: true, force: true });
+const n = readdirSync(join(outDir, "src")).length;
+console.log(`OK: legacy-free BSP erzeugt (${n} Dateien) in ${join(outDir, "src")} ${ownBackend ? "[eigener Backend-Handler]" : "[geteilter Backend-Handler /sap/bc/z2ui5]"}`);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "description": "Layout Management for abap2UI5.",
     "scripts": {
       "build_bsp" : "git clone --branch cloud https://github.com/abap2UI5/frontend && rm -rf src/02/* && node .github/app2bsp/run.js && npm run cleanup",
+      "build_legacy_free" : "rm -rf lf_cloud && git clone --depth 1 --branch cloud https://github.com/abap2UI5/frontend lf_cloud && node legacy_free/build-legacy-free.mjs . lf_cloud/app/webapp legacy_free/out && rm -rf lf_cloud",
       "cleanup" : "rm -rf frontend && rm -rf app "
     },
     "repository": {


### PR DESCRIPTION
## Summary
Introduces a new build pipeline to generate a legacy-free (UI5 2.0) variant of the frontend by adapting only the bootstrap layer while keeping all application code 1:1 compatible.

## Key Changes

- **New build script** (`legacy_free/build-legacy-free.mjs`): Orchestrates the legacy-free build process by:
  - Cloning the classic webapp from the `cloud` branch
  - Applying minimal bootstrap patches to `index.html` and `manifest.json`
  - Reusing existing `.github/app2bsp` and `bsp_rename` tooling
  - Generating a parallel BSP deployment (`Z2UI5_V2`) with optional isolated backend handler

- **Bootstrap adaptations** (only changes to existing files):
  - `index.html`: Loads OpenUI5 1.142.0-legacy-free SDK from CDN; updates config attributes to 2.x naming (`resource-roots`, `on-init`, `compat-version`, `frame-options`); adds preconnect hints; declares `libs=sap.m`
  - `manifest.json`: Updates `minUI5Version` to 1.136.0 and `_version` to 2.0.0

- **Documentation** (`legacy_free/README.md`): Explains the build process, usage, and rationale for the 1:1 approach

- **Build integration** (`package.json`): Adds `build_legacy_free` npm script for easy invocation

- **Git configuration** (`.gitignore`): Excludes build artifacts and temporary clones

## Implementation Details

The build leverages existing infrastructure (app2bsp, bsp_rename) to minimize custom logic. The only substantive changes are targeted patches to enable legacy-free bootstrap—the application code remains completely unchanged, demonstrating forward compatibility. Backend datasource defaults to shared (`/sap/bc/z2ui5`) but can be isolated via `--own-backend` flag.

https://claude.ai/code/session_0159bUaFgYpVf16vJocRzmma