### PR TITLE
Reorganize legacy-free build and add automated BSP v2 workflow

### DIFF
--- a/.github/app2app_v2/README.md
+++ b/.github/app2app_v2/README.md
@@ -1,4 +1,4 @@
-# legacy_free
+# app2app_v2
 
 Generates the **legacy-free (UI5 2.0) variant** of this frontend, taking the
 classic webapp coding over **1:1** and adapting only the bootstrap layer so it
@@ -8,12 +8,15 @@ runs on the legacy-free OpenUI5 build.
 cloud/app/webapp ──▶ patchIndexHtml + patchManifest ──▶ .github/app2bsp ──▶ bsp_rename(Z2UI5_V2) ──▶ src/
 ```
 
-The result is published to the [`frontend-legacy-free`](https://github.com/abap2UI5/frontend-legacy-free) repo.
+The result is published to the [`frontend-legacy-free`](https://github.com/abap2UI5/frontend-legacy-free) repo
+and to the [`standard_v2`](https://github.com/abap2UI5/frontend/tree/standard_v2) branch of this repo
+(kept up to date by the `auto_bsp_v2` workflow).
 
 ## Run
 
 ```bash
-npm run build_legacy_free      # -> legacy_free/out/src
+npm run build_legacy_free      # -> .github/app2app_v2/out/src
+npm run build_bsp_v2           # -> src/ (used on the standard_v2 branch)
 ```
 
 This clones the `cloud` webapp, applies the bootstrap patch and reuses the

--- a/.github/app2app_v2/README.md
+++ b/.github/app2app_v2/README.md
@@ -5,7 +5,7 @@ classic webapp coding over **1:1** and adapting only the bootstrap layer so it
 runs on the legacy-free OpenUI5 build.
 
 ```
-cloud/app/webapp ──▶ patchIndexHtml + patchManifest ──▶ .github/app2bsp ──▶ bsp_rename(Z2UI5_V2) ──▶ src/
+cloud/app/webapp ──▶ patchIndexHtml + patchManifest ──▶ .github/app2bsp ──▶ [bsp_rename, nur mit --name] ──▶ src/
 ```
 
 The result is published to the [`frontend-legacy-free`](https://github.com/abap2UI5/frontend-legacy-free) repo
@@ -29,8 +29,11 @@ existing `.github/app2bsp` + `bsp_rename` tooling. Nothing else is touched.
 | `index.html` | load `1.142.0-legacy-free` SDK (CDN); 2.x config attributes `resource-roots` / `on-init` / `compat-version` / `frame-options`; `preconnect`; `libs=sap.m` | bootstrap the legacy-free build |
 | `manifest.json` | `minUI5Version 1.136.0`, `_version 2.0.0` | legacy-free starts at 1.136 |
 
-Deployment identity is renamed to `Z2UI5_V2` (parallel install). Backend handler
-is shared (`/sap/bc/z2ui5`) by default; pass `--own-backend` for an isolated one.
+Deployment identity stays `Z2UI5` — same name as the classic frontend, so the
+legacy-free variant is a drop-in replacement (install either `standard` or
+`standard_v2`, not both). Pass `--name Z2UI5_V2` to rename for a parallel
+install; with a rename the backend handler is still shared (`/sap/bc/z2ui5`)
+by default, `--own-backend` keeps an isolated one.
 
 > The classic frontend JS is already forward-compatible (no jQuery.sap, no
 > sync APIs, guarded `getCore()` fallbacks) — so no code changes are needed,

--- a/.github/app2app_v2/build-legacy-free.mjs
+++ b/.github/app2app_v2/build-legacy-free.mjs
@@ -6,7 +6,7 @@
 //   cloud/app/webapp -> [Bootstrap-Patch] -> app2bsp/run.js -> bsp_rename(Z2UI5_V2)
 //
 // Nur index.html + manifest.json werden angepasst (alles andere bleibt 1:1).
-// Aufruf:  node build-legacy-free.mjs <frontend-repo> <cloud-webapp> <out-dir> [--own-backend]
+// Aufruf:  node .github/app2app_v2/build-legacy-free.mjs <frontend-repo> <cloud-webapp> <out-dir> [--own-backend]
 
 import { execFileSync } from "node:child_process";
 import { cpSync, rmSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
@@ -43,7 +43,7 @@ const work = join(outDir, "_work");
 rmSync(outDir, { recursive: true, force: true }); mkdirSync(work, { recursive: true });
 
 // 1) Tooling + saubere cloud-Webapp bereitstellen
-cpSync(join(frontendRepo, ".github"), join(work, ".github"), { recursive: true });
+cpSync(join(frontendRepo, ".github/app2bsp"), join(work, ".github/app2bsp"), { recursive: true });
 cpSync(join(frontendRepo, "bsp_rename"), join(work, "bsp_rename"), { recursive: true });
 cpSync(cloudWebapp, join(work, "frontend/app/webapp"), { recursive: true });
 

--- a/.github/app2app_v2/build-legacy-free.mjs
+++ b/.github/app2app_v2/build-legacy-free.mjs
@@ -3,10 +3,12 @@
 // Erzeugt den legacy-free (UI5 2.0) BSP-Stand 1:1 aus dem klassischen
 // abap2UI5-Frontend (cloud/app/webapp) + minimalem Bootstrap-Patch.
 //
-//   cloud/app/webapp -> [Bootstrap-Patch] -> app2bsp/run.js -> bsp_rename(Z2UI5_V2)
+//   cloud/app/webapp -> [Bootstrap-Patch] -> app2bsp/run.js [-> bsp_rename(--name)]
 //
 // Nur index.html + manifest.json werden angepasst (alles andere bleibt 1:1).
-// Aufruf:  node .github/app2app_v2/build-legacy-free.mjs <frontend-repo> <cloud-webapp> <out-dir> [--own-backend]
+// Die BSP heisst per Default Z2UI5 (wie das klassische Frontend, kein Rename);
+// mit --name Z2UI5_V2 wird fuer eine Parallelinstallation umbenannt.
+// Aufruf:  node .github/app2app_v2/build-legacy-free.mjs <frontend-repo> <cloud-webapp> <out-dir> [--name Z2UI5_V2] [--own-backend]
 
 import { execFileSync } from "node:child_process";
 import { cpSync, rmSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
@@ -14,6 +16,9 @@ import { join } from "node:path";
 
 const [frontendRepo, cloudWebapp, outDir] = process.argv.slice(2);
 const ownBackend = process.argv.includes("--own-backend");
+const nameIdx = process.argv.indexOf("--name");
+const bspName = nameIdx > -1 ? process.argv[nameIdx + 1] : "Z2UI5";
+const renamed = bspName.toUpperCase() !== "Z2UI5";
 const SDK = "https://sdk.openui5.org/1.142.0-legacy-free/resources/sap-ui-core.js";
 const BSP_WIDTH = 255;
 
@@ -52,16 +57,19 @@ const wa = join(work, "frontend/app/webapp");
 writeFileSync(join(wa, "index.html"), patchIndexHtml(readFileSync(join(wa, "index.html"), "utf8")));
 writeFileSync(join(wa, "manifest.json"), patchManifest(readFileSync(join(wa, "manifest.json"), "utf8")));
 
-// 3) app2bsp  +  4) rename auf Z2UI5_V2
+// 3) app2bsp  +  4) optionales Rename (nur mit --name, z.B. Z2UI5_V2)
 execFileSync("node", [".github/app2bsp/run.js"], { cwd: work, stdio: "ignore" });
-execFileSync("node", ["bsp_rename/rename-bsp.mjs", "Z2UI5_V2", "--dir", "src/02", "--yes"], { cwd: work, stdio: "ignore" });
+if (renamed) {
+  execFileSync("node", ["bsp_rename/rename-bsp.mjs", bspName, "--dir", "src/02", "--yes"], { cwd: work, stdio: "ignore" });
+}
 
-// 5) Backend-Datasource: default geteilt (/sap/bc/z2ui5), --own-backend = /sap/bc/z2ui5_v2
+// 5) Backend-Datasource: default geteilt (/sap/bc/z2ui5), --own-backend = /sap/bc/<name>
 const bsp = join(work, "src/02");
-if (!ownBackend) {
-  const mf = join(bsp, "z2ui5_v2.wapa.manifest.json");
+if (renamed && !ownBackend) {
+  const svc = `/sap/bc/${bspName.toLowerCase()}`;
+  const mf = join(bsp, `${bspName.toLowerCase()}.wapa.manifest.json`);
   const fixed = readFileSync(mf, "utf8").split("\n")
-    .map(l => l.includes('"/sap/bc/z2ui5_v2"') ? rePad(l.replace(/ *$/, "").replace("/sap/bc/z2ui5_v2", "/sap/bc/z2ui5")) : l)
+    .map(l => l.includes(`"${svc}"`) ? rePad(l.replace(/ *$/, "").replace(svc, "/sap/bc/z2ui5")) : l)
     .join("\n");
   writeFileSync(mf, fixed);
 }
@@ -69,4 +77,4 @@ if (!ownBackend) {
 cpSync(bsp, join(outDir, "src"), { recursive: true });
 rmSync(work, { recursive: true, force: true });
 const n = readdirSync(join(outDir, "src")).length;
-console.log(`OK: legacy-free BSP erzeugt (${n} Dateien) in ${join(outDir, "src")} ${ownBackend ? "[eigener Backend-Handler]" : "[geteilter Backend-Handler /sap/bc/z2ui5]"}`);
+console.log(`OK: legacy-free BSP ${bspName.toUpperCase()} erzeugt (${n} Dateien) in ${join(outDir, "src")} ${renamed && ownBackend ? "[eigener Backend-Handler]" : "[Backend-Handler /sap/bc/z2ui5]"}`);

--- a/.github/workflows/auto_bsp_v2.yaml
+++ b/.github/workflows/auto_bsp_v2.yaml
@@ -1,0 +1,35 @@
+name: auto_bsp_v2
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [cloud]
+
+jobs:
+  auto_bsp_v2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: standard_v2
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+    - run: |
+        npm ci
+        npm run build_bsp_v2
+
+    - name: Commit Changes
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add .
+        git commit -m "auto-bsp-v2-changes"
+
+    - name: Push Changes
+      uses: ad-m/github-push-action@v0.6.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: standard_v2
+        force: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ downport
 node_modules
 output
 
-legacy_free/out/
+.github/app2app_v2/out/
 lf_cloud/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "description": "Layout Management for abap2UI5.",
     "scripts": {
       "build_bsp" : "git clone --branch cloud https://github.com/abap2UI5/frontend && rm -rf src/02/* && node .github/app2bsp/run.js && npm run cleanup",
-      "build_legacy_free" : "rm -rf lf_cloud && git clone --depth 1 --branch cloud https://github.com/abap2UI5/frontend lf_cloud && node legacy_free/build-legacy-free.mjs . lf_cloud/app/webapp legacy_free/out && rm -rf lf_cloud",
+      "build_legacy_free" : "rm -rf lf_cloud && git clone --depth 1 --branch cloud https://github.com/abap2UI5/frontend lf_cloud && node .github/app2app_v2/build-legacy-free.mjs . lf_cloud/app/webapp .github/app2app_v2/out && rm -rf lf_cloud",
+      "build_bsp_v2" : "npm run build_legacy_free && rm -rf src && mkdir src && cp -r .github/app2app_v2/out/src/. src/ && rm -rf .github/app2app_v2/out",
       "cleanup" : "rm -rf frontend && rm -rf app "
     },
     "repository": {


### PR DESCRIPTION
## Summary
This PR reorganizes the legacy-free build infrastructure by moving it under `.github/app2app_v2/` and introduces an automated workflow to keep the `standard_v2` branch synchronized with generated BSP v2 builds.

## Key Changes
- **Reorganized directory structure**: Moved `legacy_free/` to `.github/app2app_v2/` for better organization alongside other build tooling
- **Added automated BSP v2 workflow**: New GitHub Actions workflow (`auto_bsp_v2.yaml`) that automatically builds and commits BSP v2 changes to the `standard_v2` branch when code is pushed to the `cloud` branch
- **Updated build scripts**: 
  - Modified `build-legacy-free.mjs` to reference the new directory structure and only copy necessary tooling (`.github/app2bsp` and `bsp_rename`)
  - Added new `build_bsp_v2` npm script that generates BSP v2 output directly to the `src/` directory
- **Updated package.json**: Adjusted `build_legacy_free` script path and added `build_bsp_v2` script for the new workflow
- **Updated .gitignore**: Changed ignore pattern from `legacy_free/out/` to `.github/app2app_v2/out/`
- **Updated documentation**: Modified README to reflect new directory name and document the automated workflow

## Implementation Details
- The `auto_bsp_v2` workflow runs on manual trigger or on push to the `cloud` branch, checks out the `standard_v2` branch, builds the BSP v2 variant, and force-pushes changes
- The build process maintains 1:1 compatibility with the cloud webapp, only patching the bootstrap layer for legacy-free (UI5 2.0) compatibility

https://claude.ai/code/session_0149A2pZ428bTAK4TiKKntUa