### PR TITLE
Add auto_bsp_v2 workflow to cloud branch so pushes trigger the standard_v2 build

### DIFF
--- a/.github/workflows/auto_bsp_v2.yaml
+++ b/.github/workflows/auto_bsp_v2.yaml
@@ -1,0 +1,35 @@
+name: auto_bsp_v2
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [cloud]
+
+jobs:
+  auto_bsp_v2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: standard_v2
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+    - run: |
+        npm ci
+        npm run build_bsp_v2
+
+    - name: Commit Changes
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add .
+        git commit -m "auto-bsp-v2-changes"
+
+    - name: Push Changes
+      uses: ad-m/github-push-action@v0.6.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: standard_v2
+        force: true


### PR DESCRIPTION
## Problem

Pushes to `cloud` automatically update `standard` (via `auto_bsp.yaml`), but `standard_v2` was never updated — `auto_bsp_v2.yaml` has zero workflow runs.

## Cause

GitHub Actions only evaluates a `push` trigger if the workflow file exists in the pushed commit. `auto_bsp_v2.yaml` was only present on `standard` and `standard_v2`, but not on `cloud` — so its `on: push: branches: [cloud]` trigger could never fire.

## Fix

Add `.github/workflows/auto_bsp_v2.yaml` (unchanged, same content as on `standard`/`standard_v2`) to the `cloud` branch. Starting with the next push to `cloud`, the workflow will run and rebuild `standard_v2` automatically, just like `auto_bsp.yaml` does for `standard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFGescVj3S5JhSNhim2E5B

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFGescVj3S5JhSNhim2E5B)_