### PR TITLE
Skip commit step in auto_bsp workflows when build output is unchanged

### DIFF
--- a/.github/workflows/auto_bsp.yaml
+++ b/.github/workflows/auto_bsp.yaml
@@ -24,7 +24,11 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git add .
-        git commit -m "auto-bsp-changes"
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "auto-bsp-changes"
+        fi
 
     - name: Push Changes
       uses: ad-m/github-push-action@v0.6.0

--- a/.github/workflows/auto_bsp_v2.yaml
+++ b/.github/workflows/auto_bsp_v2.yaml
@@ -25,7 +25,11 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git add .
-        git commit -m "auto-bsp-v2-changes"
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "auto-bsp-v2-changes"
+        fi
 
     - name: Push Changes
       uses: ad-m/github-push-action@v0.6.0


### PR DESCRIPTION
## Problem

The `auto_bsp` job failed on the last push to `cloud` (run 28744552838):

```
On branch standard
nothing to commit, working tree clean
##[error]Process completed with exit code 1
```

The merge of #42 only changed a workflow file, so the BSP build for `standard` produced no diff. `git commit` exits with code 1 when there is nothing to commit, which fails the step. The same latent bug exists in `auto_bsp_v2.yaml` — it just never surfaced before because every push to `cloud` used to change source files.

## Fix

In both `auto_bsp.yaml` and `auto_bsp_v2.yaml`, only run `git commit` when the staged diff is non-empty:

```bash
git add .
if git diff --cached --quiet; then
  echo "No changes to commit"
else
  git commit -m "auto-bsp-changes"
fi
```

The push step is unaffected — pushing an unchanged branch is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFGescVj3S5JhSNhim2E5B

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFGescVj3S5JhSNhim2E5B)_