### PR TITLE
Add ICF handler and package structure for legacy-free BSP

### DIFF
--- a/.github/app2app_v2/README.md
+++ b/.github/app2app_v2/README.md
@@ -8,6 +8,14 @@ runs on the legacy-free OpenUI5 build.
 cloud/app/webapp ──▶ patchIndexHtml + patchManifest ──▶ .github/app2bsp ──▶ [bsp_rename, nur mit --name] ──▶ src/
 ```
 
+The output uses the same package layout as the `standard` branch:
+
+```
+src/package.devc.xml   root package
+src/01/                ICF handler (SICF node + Z2UI5_CL_LP_HANDLER, from static_files/)
+src/02/                the BSP page
+```
+
 The result is published to the [`frontend-legacy-free`](https://github.com/abap2UI5/frontend-legacy-free) repo
 and to the [`standard_v2`](https://github.com/abap2UI5/frontend/tree/standard_v2) branch of this repo
 (kept up to date by the `auto_bsp_v2` workflow).

--- a/.github/app2app_v2/build-legacy-free.mjs
+++ b/.github/app2app_v2/build-legacy-free.mjs
@@ -6,6 +6,10 @@
 //   cloud/app/webapp -> [Bootstrap-Patch] -> app2bsp/run.js [-> bsp_rename(--name)]
 //
 // Nur index.html + manifest.json werden angepasst (alles andere bleibt 1:1).
+// Das Ergebnis hat dieselbe Paketstruktur wie der standard-Branch:
+//   src/package.devc.xml  (Root-Paket)
+//   src/01/               (ICF-Handler, aus static_files)
+//   src/02/               (BSP-Seite)
 // Die BSP heisst per Default Z2UI5 (wie das klassische Frontend, kein Rename);
 // mit --name Z2UI5_V2 wird fuer eine Parallelinstallation umbenannt.
 // Aufruf:  node .github/app2app_v2/build-legacy-free.mjs <frontend-repo> <cloud-webapp> <out-dir> [--name Z2UI5_V2] [--own-backend]
@@ -74,7 +78,12 @@ if (renamed && !ownBackend) {
   writeFileSync(mf, fixed);
 }
 
-cpSync(bsp, join(outDir, "src"), { recursive: true });
+// 6) Paketstruktur wie im standard-Branch: Root-Paket + 01 (ICF-Handler) + 02 (BSP)
+const staticFiles = join(frontendRepo, ".github/app2app_v2/static_files");
+mkdirSync(join(outDir, "src"), { recursive: true });
+cpSync(join(staticFiles, "package.devc.xml"), join(outDir, "src/package.devc.xml"));
+cpSync(join(staticFiles, "01"), join(outDir, "src/01"), { recursive: true });
+cpSync(bsp, join(outDir, "src/02"), { recursive: true });
 rmSync(work, { recursive: true, force: true });
-const n = readdirSync(join(outDir, "src")).length;
-console.log(`OK: legacy-free BSP ${bspName.toUpperCase()} erzeugt (${n} Dateien) in ${join(outDir, "src")} ${renamed && ownBackend ? "[eigener Backend-Handler]" : "[Backend-Handler /sap/bc/z2ui5]"}`);
+const n = readdirSync(join(outDir, "src/02")).length;
+console.log(`OK: legacy-free BSP ${bspName.toUpperCase()} erzeugt (${n} Dateien) in ${join(outDir, "src/02")} ${renamed && ownBackend ? "[eigener Backend-Handler]" : "[Backend-Handler /sap/bc/z2ui5]"}`);

--- a/.github/app2app_v2/static_files/01/package.devc.xml
+++ b/.github/app2app_v2/static_files/01/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>abap2UI5 - service</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/.github/app2app_v2/static_files/01/z2ui5          aba643b150c02b2e28e7a7e17.sicf.xml
+++ b/.github/app2app_v2/static_files/01/z2ui5          aba643b150c02b2e28e7a7e17.sicf.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_SICF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <URL>/sap/bc/z2ui5/</URL>
+   <ICFSERVICE>
+    <ICF_NAME>Z2UI5</ICF_NAME>
+    <ORIG_NAME>z2ui5</ORIG_NAME>
+   </ICFSERVICE>
+   <ICFDOCU>
+    <ICF_NAME>Z2UI5</ICF_NAME>
+    <ICF_LANGU>E</ICF_LANGU>
+    <ICF_DOCU>abap2UI5 - Frontend HTTP Service</ICF_DOCU>
+   </ICFDOCU>
+   <ICFHANDLER_TABLE>
+    <ICFHANDLER>
+     <ICF_NAME>Z2UI5</ICF_NAME>
+     <ICFORDER>01</ICFORDER>
+     <ICFTYP>A</ICFTYP>
+     <ICFHANDLER>Z2UI5_CL_LP_HANDLER</ICFHANDLER>
+    </ICFHANDLER>
+   </ICFHANDLER_TABLE>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/.github/app2app_v2/static_files/01/z2ui5_cl_lp_handler.clas.abap
+++ b/.github/app2app_v2/static_files/01/z2ui5_cl_lp_handler.clas.abap
@@ -1,0 +1,24 @@
+CLASS Z2UI5_CL_LP_HANDLER DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    INTERFACES if_http_extension.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS Z2UI5_CL_LP_HANDLER IMPLEMENTATION.
+
+  METHOD if_http_extension~handle_request.
+
+    z2ui5_cl_http_handler=>run( server ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/.github/app2app_v2/static_files/01/z2ui5_cl_lp_handler.clas.xml
+++ b/.github/app2app_v2/static_files/01/z2ui5_cl_lp_handler.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_LP_HANDLER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abap2UI5 - HTTP Handler Launchpad</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/.github/app2app_v2/static_files/package.devc.xml
+++ b/.github/app2app_v2/static_files/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>abap2UI5 - frontend</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
## Summary
This PR restructures the legacy-free BSP build output to match the standard branch's package layout by introducing an ICF handler component and organizing files into a hierarchical package structure.

## Key Changes
- **Added ICF Handler Component**: Created `Z2UI5_CL_LP_HANDLER` class that implements `if_http_extension` to handle HTTP requests by delegating to `z2ui5_cl_http_handler=>run()`
- **Added SICF Configuration**: Created ICF service node configuration (`z2ui5.sicf.xml`) that registers the HTTP handler at `/sap/bc/z2ui5/`
- **Restructured Package Layout**: Modified build script to organize output into three-level package hierarchy:
  - `src/package.devc.xml` - Root package (abap2UI5 - frontend)
  - `src/01/` - ICF handler package with SICF node and handler class
  - `src/02/` - BSP page content
- **Updated Build Script**: Modified `build-legacy-free.mjs` to copy static files (ICF handler) and organize BSP into the new structure instead of placing it directly in `src/`
- **Updated Documentation**: Added README section explaining the new package layout structure

## Implementation Details
- The ICF handler is a minimal wrapper that delegates all HTTP request handling to the existing `z2ui5_cl_http_handler` class
- Static files are now sourced from `.github/app2app_v2/static_files/` directory, allowing reusable component definitions
- The build output now mirrors the structure of the standard branch, enabling consistency across deployment variants

https://claude.ai/code/session_01UxAwymYWPmbpJJgB3sR2S7