### PR TITLE
Build standard_v2 from a standard checkout so it gets the ICF handler

### DIFF
--- a/.github/app2app_v2/README.md
+++ b/.github/app2app_v2/README.md
@@ -18,7 +18,8 @@ src/02/                the BSP page
 
 The result is published to the [`frontend-legacy-free`](https://github.com/abap2UI5/frontend-legacy-free) repo
 and to the [`standard_v2`](https://github.com/abap2UI5/frontend/tree/standard_v2) branch of this repo
-(kept up to date by the `auto_bsp_v2` workflow).
+(kept up to date by the `auto_bsp_v2` workflow, which builds on a `standard`
+checkout and force-pushes the result to `standard_v2`).
 
 ## Run
 

--- a/.github/workflows/auto_bsp_v2.yaml
+++ b/.github/workflows/auto_bsp_v2.yaml
@@ -10,9 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+    # Build from standard: it hosts the v2 build tooling (app2app_v2 incl.
+    # the ICF handler static_files), so standard_v2 always gets the same
+    # tooling and package layout as standard instead of rebuilding itself
+    # with its own, potentially stale copy.
     - uses: actions/checkout@v3
       with:
-        ref: standard_v2
+        ref: standard
     - uses: actions/setup-node@v3
       with:
         node-version: 20
@@ -25,7 +29,11 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git add .
-        git commit -m "auto-bsp-v2-changes"
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "auto-bsp-v2-changes"
+        fi
 
     - name: Push Changes
       uses: ad-m/github-push-action@v0.6.0


### PR DESCRIPTION
## Summary
Follow-up to #45: the package-layout fix never took effect on `standard_v2` because the `auto_bsp_v2` workflow checks out `standard_v2` and rebuilds it with its **own committed copy** of the build tooling — the fix merged to `standard` never reaches it (chicken-and-egg). The manual dispatch run additionally failed with `nothing to commit` because the `standard` copy of the workflow lacks the empty-commit guard from #43.

## Changes
- `auto_bsp_v2.yaml` now checks out **`standard`** instead of `standard_v2`: `standard` hosts the canonical `app2app_v2` tooling incl. the ICF handler `static_files`, and the result is force-pushed to `standard_v2` as before. `standard_v2` therefore always matches `standard`'s package layout (`src/package.devc.xml` + `src/01` ICF handler + `src/02` BSP) and automatically picks up future tooling changes.
- Skip the commit step when the build output is unchanged (same guard the `cloud` copy got in #43).
- README note on how `standard_v2` is published.

## Verification
Ran `npm run build_bsp_v2` locally on the current `standard` state — exactly what the workflow will execute. Output: `src/package.devc.xml`, `src/01/` with the SICF node + `Z2UI5_CL_LP_HANDLER`, `src/02/` with the BSP page; the `src/02` content is byte-identical to today's flat `standard_v2` `src/`.

## After merging
1. Merge the companion PR that applies the same one-line change to the `cloud` copy of the workflow (push-to-cloud triggers run that copy).
2. Run `auto_bsp_v2` once via workflow_dispatch on `standard` — `standard_v2` then immediately gets the ICF handler and the 01/02 structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxAwymYWPmbpJJgB3sR2S7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxAwymYWPmbpJJgB3sR2S7)_