### PR TITLE
auto_bsp_v2 (cloud copy): build standard_v2 from a standard checkout

### DIFF
--- a/.github/workflows/auto_bsp_v2.yaml
+++ b/.github/workflows/auto_bsp_v2.yaml
@@ -10,9 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+    # Build from standard: it hosts the v2 build tooling (app2app_v2 incl.
+    # the ICF handler static_files), so standard_v2 always gets the same
+    # tooling and package layout as standard instead of rebuilding itself
+    # with its own, potentially stale copy.
     - uses: actions/checkout@v3
       with:
-        ref: standard_v2
+        ref: standard
     - uses: actions/setup-node@v3
       with:
         node-version: 20


### PR DESCRIPTION
## Summary
Companion to #46 for the `cloud` copy of `auto_bsp_v2.yaml` — pushes to `cloud` run this copy, so it needs the same change.

## Changes
- Check out `standard` instead of `standard_v2` when rebuilding: `standard` hosts the canonical `app2app_v2` tooling incl. the ICF handler `static_files`, so `standard_v2` always gets the same tooling and package layout as `standard` (`src/package.devc.xml` + `src/01` ICF handler + `src/02` BSP) instead of rebuilding itself with its own, potentially stale copy. The result is force-pushed to `standard_v2` as before.

The empty-commit guard from #43 is already present in this copy and is kept unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxAwymYWPmbpJJgB3sR2S7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxAwymYWPmbpJJgB3sR2S7)_