### PR TITLE
Migrate manifest routing options to v2 schema for legacy-free

### DIFF
--- a/.github/app2app_v2/README.md
+++ b/.github/app2app_v2/README.md
@@ -36,7 +36,7 @@ existing `.github/app2bsp` + `bsp_rename` tooling. Nothing else is touched.
 | File | Change | Why |
 | --- | --- | --- |
 | `index.html` | load `1.142.0-legacy-free` SDK (CDN); 2.x config attributes `resource-roots` / `on-init` / `compat-version` / `frame-options`; `preconnect`; `libs=sap.m` | bootstrap the legacy-free build |
-| `manifest.json` | `minUI5Version 1.136.0` | legacy-free starts at 1.136 (`_version` stays at 1.65: schema v2 rejects the v1-style `sap.ui5/routing` options and the component fails to load) |
+| `manifest.json` | `minUI5Version 1.136.0`, `_version 2.0.0`, routing options migrated to manifest v2 (`viewPath`/`viewName`/`viewId` → `path`/`name`/`id` + `type: "View"`, `async` dropped) | legacy-free starts at 1.136; schema v2 rejects the v1-style routing options (component would fail to load with a blank page) |
 
 Deployment identity stays `Z2UI5` — same name as the classic frontend, so the
 legacy-free variant is a drop-in replacement (install either `standard` or

--- a/.github/app2app_v2/README.md
+++ b/.github/app2app_v2/README.md
@@ -36,7 +36,7 @@ existing `.github/app2bsp` + `bsp_rename` tooling. Nothing else is touched.
 | File | Change | Why |
 | --- | --- | --- |
 | `index.html` | load `1.142.0-legacy-free` SDK (CDN); 2.x config attributes `resource-roots` / `on-init` / `compat-version` / `frame-options`; `preconnect`; `libs=sap.m` | bootstrap the legacy-free build |
-| `manifest.json` | `minUI5Version 1.136.0`, `_version 2.0.0` | legacy-free starts at 1.136 |
+| `manifest.json` | `minUI5Version 1.136.0` | legacy-free starts at 1.136 (`_version` stays at 1.65: schema v2 rejects the v1-style `sap.ui5/routing` options and the component fails to load) |
 
 Deployment identity stays `Z2UI5` — same name as the classic frontend, so the
 legacy-free variant is a drop-in replacement (install either `standard` or

--- a/.github/app2app_v2/build-legacy-free.mjs
+++ b/.github/app2app_v2/build-legacy-free.mjs
@@ -39,8 +39,12 @@ function patchIndexHtml(s) {
     .replace(/(data-sap-ui-frameOptions="trusted")/, `data-sap-ui-frame-options="trusted"\n        data-sap-ui-libs="sap.m"`);
 }
 function patchManifest(s) {
+  // "_version" bewusst NICHT auf 2.0.0 anheben: Schema-Version 2 aktiviert die
+  // strikte Manifest-v2-Semantik, in der die v1-Routing-Optionen (viewName/
+  // viewId/viewPath unter sap.ui5/routing/targets) einen Fehler werfen ->
+  // "Failed to load component for container container", leere Seite.
+  // Die legacy-free Runtime akzeptiert Schema v1 unveraendert.
   return s
-    .replace(/"_version":\s*"1\.65\.0"/, '"_version": "2.0.0"')
     .replace(/"minUI5Version":\s*"1\.71\.0"/, '"minUI5Version": "1.136.0"');
 }
 

--- a/.github/app2app_v2/build-legacy-free.mjs
+++ b/.github/app2app_v2/build-legacy-free.mjs
@@ -39,13 +39,32 @@ function patchIndexHtml(s) {
     .replace(/(data-sap-ui-frameOptions="trusted")/, `data-sap-ui-frame-options="trusted"\n        data-sap-ui-libs="sap.m"`);
 }
 function patchManifest(s) {
-  // "_version" bewusst NICHT auf 2.0.0 anheben: Schema-Version 2 aktiviert die
-  // strikte Manifest-v2-Semantik, in der die v1-Routing-Optionen (viewName/
-  // viewId/viewPath unter sap.ui5/routing/targets) einen Fehler werfen ->
-  // "Failed to load component for container container", leere Seite.
-  // Die legacy-free Runtime akzeptiert Schema v1 unveraendert.
-  return s
-    .replace(/"minUI5Version":\s*"1\.71\.0"/, '"minUI5Version": "1.136.0"');
+  const m = JSON.parse(s);
+  m._version = "2.0.0";
+  m["sap.ui5"].dependencies.minUI5Version = "1.136.0";
+  // Schema-Version 2 aktiviert die strikte Manifest-v2-Semantik: die alten
+  // Routing-Optionen viewPath/viewName/viewId werfen dann beim Erzeugen des
+  // Routers (Targets._validateOptions) -> "Failed to load component for
+  // container container", leere Seite. Deshalb hier auf die modernen
+  // Optionen path/name/id + type "View" umstellen; async erzwingt Schema 2
+  // selbst.
+  const rename = (o, from, to) => {
+    if (o && Object.hasOwn(o, from)) { o[to] = o[from]; delete o[from]; }
+  };
+  const routing = m["sap.ui5"].routing;
+  if (routing?.config) {
+    rename(routing.config, "viewPath", "path");
+    rename(routing.config, "viewName", "name");
+    rename(routing.config, "viewId", "id");
+    routing.config.type ??= "View";
+    delete routing.config.async;
+  }
+  for (const t of Object.values(routing?.targets ?? {})) {
+    rename(t, "viewPath", "path");
+    rename(t, "viewName", "name");
+    rename(t, "viewId", "id");
+  }
+  return JSON.stringify(m, null, 2) + "\n";
 }
 
 // BSP-Page-Format (255-Zeichen-Zeilen, kein Schluss-Newline) – wie app2bsp


### PR DESCRIPTION
## Summary
Updated the manifest patching logic for the legacy-free build to properly migrate routing configuration from manifest v1 to v2 schema, ensuring compatibility with the stricter validation in schema v2.

## Key Changes
- **Refactored `patchManifest()` function**: Changed from regex-based string replacements to JSON parsing and manipulation for more robust and maintainable manifest updates
- **Automated routing migration**: Added logic to rename v1-style routing options to v2 equivalents:
  - `viewPath` → `path`
  - `viewName` → `name`
  - `viewId` → `id`
  - Added `type: "View"` to routing config
  - Removed `async` property from routing config
- **Applied to all routing targets**: Migration logic handles both the global routing config and individual target definitions
- **Updated documentation**: Clarified in README why these routing changes are necessary (schema v2 rejects v1-style options, causing component load failures)

## Implementation Details
- Uses `JSON.parse()` and `JSON.stringify()` for safe manifest manipulation instead of fragile regex patterns
- Implements a reusable `rename()` helper function to safely rename object properties
- Preserves manifest formatting with 2-space indentation and trailing newline
- Includes detailed German comments explaining the schema v2 requirements and why the migration is necessary
- Uses optional chaining and nullish coalescing operators for safe property access

https://claude.ai/code/session_01EWq314eDtje5uZLUyjG6BS