### PR TITLE
Exclude the system-specific BSP MIME folder SMIM from the v2 build

### DIFF
--- a/.github/app2app_v2/build-legacy-free.mjs
+++ b/.github/app2app_v2/build-legacy-free.mjs
@@ -107,6 +107,12 @@ mkdirSync(join(outDir, "src"), { recursive: true });
 cpSync(join(staticFiles, "package.devc.xml"), join(outDir, "src/package.devc.xml"));
 cpSync(join(staticFiles, "01"), join(outDir, "src/01"), { recursive: true });
 cpSync(bsp, join(outDir, "src/02"), { recursive: true });
+// Das SMIM-Serialisat des BSP-MIME-Ordners nicht ausliefern: sein Objekt-
+// schluessel (Dateiname) ist die LOIO-GUID des Ordners auf dem System, das
+// ihn urspruenglich serialisiert hat. Auf jedem anderen System legt der
+// BSP-Pull den MIME-Ordner selbst mit eigener GUID an - das Repo-Objekt
+// existiert dort nie und abapGit zeigt dauerhaft einen Diff.
+rmSync(join(outDir, "src/02/024251849e5a1edfa0b19c97d05e28c2.smim.xml"), { force: true });
 rmSync(work, { recursive: true, force: true });
 const n = readdirSync(join(outDir, "src/02")).length;
 console.log(`OK: legacy-free BSP ${bspName.toUpperCase()} erzeugt (${n} Dateien) in ${join(outDir, "src/02")} ${renamed && ownBackend ? "[eigener Backend-Handler]" : "[Backend-Handler /sap/bc/z2ui5]"}`);


### PR DESCRIPTION
abapGit pulls of standard_v2 always showed one remaining diff: src/02/024251849e5a1edfa0b19c97d05e28c2.smim.xml. The file serializes the BSP MIME folder /SAP/BC/BSP/SAP/Z2UI5, and its object key (the file name) is the folder's LOIO GUID on the system that originally serialized it. On every other system the BSP pull auto-creates the MIME folder with its own GUID, so the repo object never exists there and abapGit permanently reports a diff.

Drop the file from the build output; the folder is created by the pull anyway. The build now reproduces the state a pulled system serializes back, byte for byte (verified against standard_v2 after the manual 'fix diffs' commit 4da6d94).


Claude-Session: https://claude.ai/code/session_01EWq314eDtje5uZLUyjG6BS