### PR TITLE
Fix abaplint.jsonc formatting issue

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -1,4 +1,3 @@
-@@ -1,36 +0,0 @@
 {
     "global": {
       "files": "/abap/cloud/**/*.*"


### PR DESCRIPTION
## Summary
Corrected a formatting artifact in the abaplint.jsonc configuration file that was preventing proper parsing.

## Changes
- Removed erroneous diff header line (`@@ -1,36 +0,0 @@`) that was inadvertently included in the configuration file
- This line was causing the JSON configuration to be malformed and unreadable

## Details
The abaplint.jsonc file had a git diff header line at the beginning that should not have been part of the actual configuration. Removing this line restores the file to valid JSON format and allows abaplint to properly parse the configuration.

https://claude.ai/code/session_01RyaAZgp2wuMJiq74jAxUfL