### PR TITLE
Improve branch build workflow with proper parent tracking

### DIFF
--- a/.github/build-branches.mjs
+++ b/.github/build-branches.mjs
@@ -63,6 +63,10 @@ function initBranch(branch, abapgitXml) {
   for (const f of COMMON) if (existsSync(join(repo, f))) cpSync(join(repo, f), join(dir, f));
   writeFileSync(join(dir, "README.md"), banner(branch) + readFileSync(join(repo, "README.md"), "utf8"));
   writeFileSync(join(dir, ".abapgit.xml"), abapgitXml);
+  // abaplint-Config von main, Quellpfad auf /src/ der Output-Branches gedreht;
+  // ohne sie meldet der abaplint-Check auf den Output-Branches immer rot
+  writeFileSync(join(dir, "abaplint.jsonc"),
+    readFileSync(join(repo, "abaplint.jsonc"), "utf8").replaceAll("/abap/cloud/", "/src/"));
   return dir;
 }
 

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -36,13 +36,10 @@ jobs:
       run: node .github/build-branches.mjs "${{ inputs.branch }}"
 
     # ABAP-Check des generierten standard-Trees (BSP + On-Prem-Handler),
-    # wie bisher ABAP_STANDARD; gleiche Config, Quellen dort unter /src/
+    # wie bisher ABAP_STANDARD; die abaplint.jsonc liegt jetzt im Output
     - name: Lint generated standard src
       if: inputs.branch == 'standard'
-      run: |
-        sed 's|/abap/cloud/|/src/|' abaplint.jsonc > .github/out/standard/abaplint.jsonc
-        (cd .github/out/standard && npx abaplint)
-        rm .github/out/standard/abaplint.jsonc
+      run: (cd .github/out/standard && npx abaplint)
 
     - name: Push ${{ inputs.branch }}
       run: |

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -2,8 +2,10 @@ name: build_branch
 
 # Wiederverwendbarer Basis-Workflow: baut EINEN generierten Output-Branch
 # aus main und pusht ihn als Commit oben auf die bestehende Branch-Historie
-# (ohne inhaltliche Aenderung wird nichts gepusht). Aufgerufen von den
-# vier build_<branch>-Workflows.
+# (ohne inhaltliche Aenderung wird nichts gepusht). Der main-Commit wird als
+# zweiter Parent mitgefuehrt, damit GitHub den Branch als "ahead" statt
+# "behind" gegenueber main anzeigt. Aufgerufen von den vier
+# build_<branch>-Workflows.
 
 on:
   workflow_call:
@@ -57,6 +59,6 @@ jobs:
           echo "$b: keine Aenderungen"
           exit 0
         fi
-        commit=$(git commit-tree "$tree" ${parent:+-p "$parent"} -m "build: $b from $GITHUB_SHA")
+        commit=$(git commit-tree "$tree" ${parent:+-p "$parent"} -p "$GITHUB_SHA" -m "build: $b from $GITHUB_SHA")
         git push origin "$commit:refs/heads/$b"
         echo "$b: $commit gepusht"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.github/out/


### PR DESCRIPTION
## Summary
This PR refactors the branch build workflow to properly track the main branch as a parent commit, ensuring generated output branches display correctly in GitHub's UI. It also simplifies the linting process by moving the abaplint configuration generation into the build script.

## Key Changes
- **Parent commit tracking**: Modified the git commit-tree command to include the main branch commit (`$GITHUB_SHA`) as a second parent, so GitHub displays output branches as "ahead" rather than "behind" main
- **Simplified linting**: Moved abaplint.jsonc generation from the workflow step into `build-branches.mjs`, eliminating the need for sed transformations and temporary file cleanup in the workflow
- **Path transformation**: The abaplint configuration now automatically replaces `/abap/cloud/` paths with `/src/` to match the output branch structure
- **Build script enhancement**: Added abaplint.jsonc generation to the `initBranch()` function with explanatory comments
- **Gitignore**: Added entries for `node_modules/` and `.github/out/` directories

## Implementation Details
- The abaplint configuration is now generated once during the build process and placed directly in the output branch directory
- The merge commit strategy (with two parents) maintains proper Git history while improving branch status visibility
- The path replacement logic is centralized in the build script, reducing workflow complexity and improving maintainability

https://claude.ai/code/session_01HGDaeyayGiKPdZofNofFZq