### PR TITLE
Add support for custom-named BSP variants via build_custom workflow

### DIFF
--- a/.github/bsp_rename/README.md
+++ b/.github/bsp_rename/README.md
@@ -6,6 +6,29 @@ way this repo ships as `Z2UI5` and `frontend-legacy-free` ships as `Z2UI5_V2`.
 
 Dependency-free Node script (Node 16+). Nothing to install.
 
+## Renamed branches via `build_custom` (recommended)
+
+The easiest way to get a renamed install: run the **`build_custom`** GitHub
+workflow (Actions → build_custom → Run workflow), pick the base variant
+(`standard` or `standard_v2`) and enter the new BSP name (e.g. `ZMYUI5`).
+It builds the base branch, applies this rename script to the generated `src`
+tree and pushes the result as branch **`standard_<name>`** /
+**`standard_v2_<name>`** (name lowercased) — ready to pull with abapGit.
+Re-running the workflow with the same name updates the branch to the current
+`main` state.
+
+The same build runs locally with
+
+```bash
+node .github/build-branches.mjs standard_zmyui5      # -> .github/out/standard_zmyui5
+node .github/build-branches.mjs standard_v2_zmyui5   # legacy-free variant
+```
+
+The renamed branch is fully self-contained: BSP, SICF nodes and the ICF
+handler class all carry the new name, so it installs alongside an existing
+`Z2UI5` without touching it (it still requires the abap2UI5 backend, see
+below).
+
 ## Usage
 
 Run it from the **repository root** (so the default `src` path resolves):

--- a/.github/bsp_rename/rename-bsp.mjs
+++ b/.github/bsp_rename/rename-bsp.mjs
@@ -70,6 +70,13 @@ const SICF_GUID_LEN = 25;
 // Maximum length of an ICF service / BSP application name.
 const MAX_NAME_LEN = 15;
 
+// BSP pages (the z2ui5.wapa.<page> files under src/02 of the generated
+// standard branches) are stored in the abapGit WAPA page format: every line
+// space-padded to exactly 255 characters, longer lines wrapped into 255-char
+// chunks, no trailing newline (see .github/app2bsp/run.js). A content edit
+// changes line lengths, so edited page files must be re-padded afterwards.
+const BSP_LINE_WIDTH = 255;
+
 // ---------------------------------------------------------------------------
 // Argument parsing
 // ---------------------------------------------------------------------------
@@ -170,8 +177,40 @@ function transformNamespace(content, NEW_LO) {
     .replace(new RegExp(`(["'])${escapeRe(OLD_LO)}\\1`, "g"), `$1${NEW_LO}$1`); // "z2ui5"
 }
 
+// A BSP page content file (fixed-width format, see BSP_LINE_WIDTH). The page
+// directory z2ui5.wapa.xml is a normal abapGit XML and NOT in page format.
+function isBspPageFile(name) {
+  return name.startsWith(`${OLD_LO}.wapa.`) && name !== `${OLD_LO}.wapa.xml`;
+}
+
+// Re-pad a BSP page after a content edit. Only lines whose length deviates
+// from 255 are touched (those are exactly the edited ones); an over-long line
+// is re-wrapped into 255-char chunks like app2bsp/run.js does. Limitation:
+// if the renamed token sits inside an already-wrapped logical line (>255
+// chars) the chunk layout cannot be reconstructed - irrelevant in practice,
+// since the only page edited without --with-namespace is the pretty-printed
+// manifest.json whose lines are far below 255 chars.
+function renormalizeBspPage(content) {
+  const out = [];
+  for (const line of content.split("\n")) {
+    if (line.length === BSP_LINE_WIDTH) { out.push(line); continue; }
+    const text = line.replace(/ +$/, "");
+    if (text.length === 0) { out.push("".padEnd(BSP_LINE_WIDTH)); continue; }
+    for (let o = 0; o < text.length; o += BSP_LINE_WIDTH) {
+      out.push(text.slice(o, o + BSP_LINE_WIDTH).padEnd(BSP_LINE_WIDTH));
+    }
+  }
+  return out.join("\n");
+}
+
 // Decide how a file's CONTENT must be transformed, based on its name.
 function contentTransformFor(name, NEW_UP, NEW_LO, withNamespace) {
+  const tf = rawTransformFor(name, NEW_UP, NEW_LO, withNamespace);
+  if (tf && isBspPageFile(name)) return (c) => renormalizeBspPage(tf(c));
+  return tf;
+}
+
+function rawTransformFor(name, NEW_UP, NEW_LO, withNamespace) {
   if (name.endsWith(".sicf.xml")) return (c) => transformBlanket(c, NEW_UP, NEW_LO);
   if (name.endsWith(".smim.xml")) return (c) => transformBlanket(c, NEW_UP, NEW_LO);
   if (name.endsWith(".wapa.xml")) return (c) => transformBlanket(c, NEW_UP, NEW_LO); // BSP descriptor only

--- a/.github/build-branches.mjs
+++ b/.github/build-branches.mjs
@@ -8,10 +8,19 @@
 //   standard     BSP Z2UI5 (app2bsp) + ICF-Handler, klassischer Bootstrap
 //   standard_v2  BSP Z2UI5 legacy-free (build-legacy-free.mjs)
 //
+// Zusaetzlich koennen umbenannte BSP-Varianten gebaut werden (fuer eine
+// Parallelinstallation im selben SAP-System, siehe .github/bsp_rename):
+//
+//   standard_<NAME>     wie standard,    BSP/SICF/Handler auf <NAME> umbenannt
+//   standard_v2_<NAME>  wie standard_v2, BSP/SICF/Handler auf <NAME> umbenannt
+//
+// z.B. standard_zmyui5 -> BSP ZMYUI5. Der GitHub-Workflow build_custom baut
+// und pusht solche Branches on demand.
+//
 // Aufruf:  node .github/build-branches.mjs [branch ...]
-// Ohne Argumente werden alle vier gebaut; mit Argumenten nur die genannten
-// (so baut jeder build_<branch>-Workflow genau seinen Branch). Output je
-// Branch: .github/out/<branch>/
+// Ohne Argumente werden die vier festen Branches gebaut; mit Argumenten nur
+// die genannten (so baut jeder build_<branch>-Workflow genau seinen Branch).
+// Output je Branch: .github/out/<branch>/
 
 import { execFileSync } from "node:child_process";
 import { cpSync, rmSync, mkdirSync, readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
@@ -52,8 +61,9 @@ const ABAPGIT_STANDARD = `﻿<?xml version="1.0" encoding="utf-8"?>
 `;
 
 function banner(branch) {
+  const workflow = BUILDERS[branch] ? `build_${branch}` : "build_custom";
   return `> ⚙️ **Generated branch \`${branch}\`** — built from [\`main\`](../../tree/main) by the ` +
-    "`build_" + branch + "` workflow. Do not commit here, changes belong into `main`.\n\n";
+    "`" + workflow + "` workflow. Do not commit here, changes belong into `main`.\n\n";
 }
 
 function initBranch(branch, abapgitXml) {
@@ -87,8 +97,8 @@ function buildCloudVariant(branch) {
 }
 
 // Klassische BSP via app2bsp + ICF-Handler
-function buildStandard() {
-  const dir = initBranch("standard", ABAPGIT_STANDARD);
+function buildStandard(branch = "standard") {
+  const dir = initBranch(branch, ABAPGIT_STANDARD);
   const work = join(out, "_work_standard");
   cpSync(join(repo, ".github/app2bsp"), join(work, ".github/app2bsp"), { recursive: true });
   cpSync(join(repo, "app/webapp"), join(work, "frontend/app/webapp"), { recursive: true, filter: skipBuildArtifacts });
@@ -99,8 +109,8 @@ function buildStandard() {
 }
 
 // Legacy-free BSP via build-legacy-free.mjs
-function buildStandardV2() {
-  const dir = initBranch("standard_v2", ABAPGIT_STANDARD);
+function buildStandardV2(branch = "standard_v2") {
+  const dir = initBranch(branch, ABAPGIT_STANDARD);
   const work = join(out, "_work_standard_v2");
   execFileSync("node", [join(repo, ".github/app2app_v2/build-legacy-free.mjs"), repo, join(repo, "app/webapp"), work],
     { stdio: "inherit" });
@@ -111,20 +121,43 @@ function buildStandardV2() {
 const BUILDERS = {
   cloud: () => buildCloudVariant("cloud"),
   cloud_v2: () => buildCloudVariant("cloud_v2"),
-  standard: buildStandard,
-  standard_v2: buildStandardV2,
+  standard: () => buildStandard(),
+  standard_v2: () => buildStandardV2(),
 };
+
+// standard_<NAME> / standard_v2_<NAME>: Basis bauen, dann die komplette
+// Deployment-Identitaet (BSP, SICF-Knoten, Handler-Klasse, Dateinamen) im
+// generierten src-Tree auf <NAME> umbenennen. Namensvalidierung (max. 15
+// Zeichen, Z/Y-Namensraum-Warnung) uebernimmt rename-bsp.mjs.
+function renamedBuilder(branch) {
+  for (const base of ["standard_v2", "standard"]) {
+    const prefix = `${base}_`;
+    if (!branch.startsWith(prefix) || branch.length === prefix.length) continue;
+    const name = branch.slice(prefix.length);
+    const buildBase = base === "standard" ? buildStandard : buildStandardV2;
+    return () => {
+      buildBase(branch);
+      execFileSync("node",
+        [join(repo, ".github/bsp_rename/rename-bsp.mjs"), name, "--yes", "--dir", "src"],
+        { cwd: join(out, branch), stdio: "inherit" });
+    };
+  }
+  return null;
+}
 
 const requested = process.argv.slice(2);
 const branches = requested.length ? requested : Object.keys(BUILDERS);
-for (const b of branches) {
-  if (!BUILDERS[b]) {
-    console.error(`Unbekannter Branch '${b}' - erlaubt: ${Object.keys(BUILDERS).join(", ")}`);
+const builds = branches.map((b) => {
+  const build = BUILDERS[b] ?? renamedBuilder(b);
+  if (!build) {
+    console.error(`Unbekannter Branch '${b}' - erlaubt: ${Object.keys(BUILDERS).join(", ")}, standard_<name>, standard_v2_<name>`);
     process.exit(1);
   }
-}
-for (const b of branches) {
-  BUILDERS[b]();
+  return build;
+});
+for (let i = 0; i < branches.length; i++) {
+  builds[i]();
+  const b = branches[i];
   const n = readdirSync(join(out, b), { recursive: true }).length;
   console.log(`OK: ${b} (${n} Eintraege) -> ${join(out, b)}`);
 }

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -5,13 +5,14 @@ name: build_branch
 # (ohne inhaltliche Aenderung wird nichts gepusht). Der main-Commit wird als
 # zweiter Parent mitgefuehrt, damit GitHub den Branch als "ahead" statt
 # "behind" gegenueber main anzeigt. Aufgerufen von den vier
-# build_<branch>-Workflows.
+# build_<branch>-Workflows sowie von build_custom (umbenannte BSP-Varianten
+# standard_<name> / standard_v2_<name>).
 
 on:
   workflow_call:
     inputs:
       branch:
-        description: "Output-Branch: cloud | cloud_v2 | standard | standard_v2"
+        description: "Output-Branch: cloud | cloud_v2 | standard | standard_v2 | standard_<name> | standard_v2_<name>"
         required: true
         type: string
 
@@ -22,6 +23,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      BRANCH: ${{ inputs.branch }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -33,17 +36,18 @@ jobs:
     - run: npx abaplint
 
     - name: Build ${{ inputs.branch }}
-      run: node .github/build-branches.mjs "${{ inputs.branch }}"
+      run: node .github/build-branches.mjs "$BRANCH"
 
     # ABAP-Check des generierten standard-Trees (BSP + On-Prem-Handler),
-    # wie bisher ABAP_STANDARD; die abaplint.jsonc liegt jetzt im Output
+    # wie bisher ABAP_STANDARD; die abaplint.jsonc liegt jetzt im Output.
+    # Gilt auch fuer umbenannte standard_<name>-Varianten (nicht fuer v2).
     - name: Lint generated standard src
-      if: inputs.branch == 'standard'
-      run: (cd .github/out/standard && npx abaplint)
+      if: startsWith(inputs.branch, 'standard') && !startsWith(inputs.branch, 'standard_v2')
+      run: (cd ".github/out/$BRANCH" && npx abaplint)
 
     - name: Push ${{ inputs.branch }}
       run: |
-        b="${{ inputs.branch }}"
+        b="$BRANCH"
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git fetch origin "$b" --depth 1 2>/dev/null || true

--- a/.github/workflows/build_custom.yaml
+++ b/.github/workflows/build_custom.yaml
@@ -1,0 +1,63 @@
+name: build_custom
+
+# Baut eine umbenannte BSP-Variante (Parallelinstallation im selben SAP-System,
+# siehe .github/bsp_rename) und pusht sie auf den Branch <base>_<bsp-name>,
+# z.B. standard_zmyui5 oder standard_v2_zmyui5. Erneutes Ausfuehren mit
+# gleichem Namen aktualisiert den Branch mit dem aktuellen main-Stand.
+
+on:
+  workflow_dispatch:
+    inputs:
+      base:
+        description: "Basis-Variante"
+        required: true
+        type: choice
+        options:
+          - standard
+          - standard_v2
+        default: standard
+      bsp_name:
+        description: "Neuer BSP-Name (max. 15 Zeichen, Buchstabe + Buchstaben/Ziffern/_, Kundennamensraum Z*/Y*), z.B. ZMYUI5"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  # Branch-Namen ableiten und Eingabe validieren, bevor gebaut wird
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.derive.outputs.branch }}
+    steps:
+    - name: Derive branch name
+      id: derive
+      env:
+        BASE: ${{ inputs.base }}
+        BSP_NAME: ${{ inputs.bsp_name }}
+      run: |
+        if ! printf '%s' "$BSP_NAME" | grep -Eq '^[A-Za-z][A-Za-z0-9_]{0,14}$'; then
+          echo "::error::Ungueltiger BSP-Name '$BSP_NAME' (max. 15 Zeichen, Buchstabe gefolgt von Buchstaben/Ziffern/_)"
+          exit 1
+        fi
+        # standard + Name "v2..." ergaebe standard_v2_<rest> und wuerde als
+        # standard_v2-Variante gebaut - eindeutigen Namen verlangen
+        if [ "$BASE" = "standard" ] && printf '%s' "$BSP_NAME" | grep -Eiq '^v2(_|$)'; then
+          echo "::error::BSP-Name '$BSP_NAME' ist mit Basis 'standard' mehrdeutig (Branch standard_v2_*) - anderen Namen waehlen"
+          exit 1
+        fi
+        branch="${BASE}_$(printf '%s' "$BSP_NAME" | tr '[:upper:]' '[:lower:]')"
+        case "$branch" in
+          cloud|cloud_v2|standard|standard_v2)
+            echo "::error::Branch '$branch' kollidiert mit einem festen Output-Branch - anderen Namen waehlen"
+            exit 1;;
+        esac
+        echo "branch=$branch" >> "$GITHUB_OUTPUT"
+        echo "Baue Branch: $branch"
+
+  build_custom:
+    needs: prepare
+    uses: ./.github/workflows/build_branch.yaml
+    with:
+      branch: ${{ needs.prepare.outputs.branch }}

--- a/README.md
+++ b/README.md
@@ -19,5 +19,7 @@ This repository contains an abap2UI5 frontend artefacts service. For more inform
 | standard    | S/4 Private Cloud, S/4 On-Premise, R/3 NetWeaver >750 | classic | `npm run build_standard` |
 | standard_v2 | S/4 Private Cloud, S/4 On-Premise                     | legacy-free (UI5 2.x) | `npm run build_standard_v2` |
 
+Need the BSP under a **different name** (e.g. a second copy in the same system)? Run the [`build_custom` workflow](https://github.com/abap2UI5/frontend/actions/workflows/build_custom.yaml) with a base variant and the new BSP name — it generates and pushes a branch `standard_<name>` / `standard_v2_<name>` with the whole deployment identity (BSP, SICF nodes, handler class) renamed. Details in [`.github/bsp_rename`](.github/bsp_rename).
+
 #### Issues
 For bug reports or feature requests, please open an issue in the [abap2UI5 repository.](https://github.com/abap2UI5/abap2UI5/issues)


### PR DESCRIPTION
## Summary
This change adds support for building and deploying renamed BSP variants (e.g., `ZMYUI5`) alongside the standard `Z2UI5` installation in the same SAP system. A new `build_custom` GitHub workflow enables on-demand builds of custom-named branches, with the build infrastructure updated to support dynamic branch naming patterns.

## Key Changes

- **New `build_custom` workflow** (`.github/workflows/build_custom.yaml`): Accepts user input for base variant (`standard` or `standard_v2`) and desired BSP name, validates inputs, derives the output branch name, and triggers the build.

- **Enhanced build script** (`.github/build-branches.mjs`):
  - Modified `buildStandard()` and `buildStandardV2()` to accept optional branch parameter for flexible naming
  - Added `renamedBuilder()` function to handle dynamic branch patterns (`standard_<name>`, `standard_v2_<name>`)
  - Updated branch resolution logic to check fixed builders first, then attempt dynamic pattern matching
  - Improved error messages to document the new naming patterns

- **BSP page normalization** (`.github/bsp_rename/rename-bsp.mjs`):
  - Added `isBspPageFile()` to identify BSP page files (fixed-width format, 255 chars/line)
  - Added `renormalizeBspPage()` to re-pad BSP pages after content edits (handles line wrapping for renamed tokens)
  - Modified `contentTransformFor()` to apply normalization to BSP page files after transformation
  - Added `BSP_LINE_WIDTH` constant documenting the abapGit WAPA page format

- **Updated build workflow** (`.github/workflows/build_branch.yaml`):
  - Added support for custom branch names in the reusable workflow
  - Updated linting condition to apply to all `standard_<name>` variants (excluding `standard_v2_*`)
  - Uses environment variable for branch name consistency

- **Documentation updates**:
  - Added section in `.github/bsp_rename/README.md` explaining the `build_custom` workflow and local usage
  - Updated comments in build scripts and workflows to document the new capability
  - Updated main README with reference to the new workflow

## Implementation Details

- Branch name validation includes: max 15 characters, alphanumeric + underscore, customer namespace (Z*/Y*), and collision detection with fixed branch names
- Prevents ambiguous names (e.g., `standard` + name starting with `v2` would collide with `standard_v2_*` pattern)
- BSP page re-padding only touches lines that deviate from 255 characters (the edited ones), preserving unchanged content
- The renamed branch is fully self-contained with all identities (BSP, SICF nodes, handler class) updated to the new name

https://claude.ai/code/session_01YKD1egrDvrgWcb8f9Lu9JD