### PR TITLE
Clarify routing migration as transitional safeguard

### DIFF
--- a/.github/app2app_v2/README.md
+++ b/.github/app2app_v2/README.md
@@ -34,7 +34,16 @@ npm run build_branches         # alle vier; einzeln: node .github/build-branches
 | File | Change | Why |
 | --- | --- | --- |
 | `index.html` | load `1.142.0-legacy-free` SDK (CDN); 2.x config attributes `resource-roots` / `on-init` / `compat-version` / `frame-options`; `preconnect`; `libs=sap.m` | bootstrap the legacy-free build |
-| `manifest.json` | `minUI5Version 1.136.0`, `_version 2.0.0`, routing options migrated to manifest v2 (`viewPath`/`viewName`/`viewId` → `path`/`name`/`id` + `type: "View"`, `async` dropped) | legacy-free starts at 1.136; schema v2 rejects the v1-style routing options (component would fail to load with a blank page) |
+| `manifest.json` | `minUI5Version 1.136.0`, `_version 2.0.0` | legacy-free starts at 1.136 |
+
+> The webapp ships **no routing section** anymore (removed upstream in
+> abap2UI5/abap2UI5 - the shell controller starts the app directly), so
+> nothing routing-related needs patching. `patchManifest` still carries a
+> transitional migration of the classic routing options
+> (`viewPath`/`viewName`/`viewId` → `path`/`name`/`id` + `type: "View"`) as a
+> safeguard for building from a webapp state that predates the removal -
+> schema v2 rejects the v1-style options (blank page). It is a no-op for
+> current deploys and can be deleted once `main`'s webapp is synced.
 
 Deployment identity stays `Z2UI5` — same name as the classic frontend, so the
 legacy-free variant is a drop-in replacement (install either `standard` or

--- a/.github/app2app_v2/patch-v2.mjs
+++ b/.github/app2app_v2/patch-v2.mjs
@@ -21,12 +21,17 @@ export function patchManifest(s) {
   const m = JSON.parse(s);
   m._version = "2.0.0";
   m["sap.ui5"].dependencies.minUI5Version = "1.136.0";
-  // Schema-Version 2 aktiviert die strikte Manifest-v2-Semantik: die alten
-  // Routing-Optionen viewPath/viewName/viewId werfen dann beim Erzeugen des
-  // Routers (Targets._validateOptions) -> "Failed to load component for
-  // container container", leere Seite. Deshalb hier auf die modernen
-  // Optionen path/name/id + type "View" umstellen; async erzwingt Schema 2
-  // selbst.
+  // Transitional safeguard only: the upstream webapp no longer ships a
+  // routing section at all (abap2UI5/abap2UI5 removed it - the app is
+  // started by the shell controller instead), so the migration below is a
+  // no-op for current deploys. It stays for building from a webapp state
+  // that predates the removal, where schema version 2 enforces the strict
+  // manifest-v2 semantics: the old routing options viewPath/viewName/viewId
+  // throw when the router is created (Targets._validateOptions) -> "Failed
+  // to load component for container container", blank page. Hence migrate
+  // to the modern options path/name/id + type "View"; async is implied by
+  // schema 2 itself. Delete this block once main's webapp is synced past
+  // the routing removal.
   const rename = (o, from, to) => {
     if (o && Object.hasOwn(o, from)) { o[to] = o[from]; delete o[from]; }
   };


### PR DESCRIPTION
## Summary
Updated documentation and code comments to clarify that the manifest routing migration in `patchManifest` is a transitional safeguard for legacy webapp states, not a required transformation for current deployments.

## Key Changes
- **Code comment in `patch-v2.mjs`**: Expanded the comment explaining the routing options migration to clarify that:
  - The upstream webapp no longer ships a routing section (removed in abap2UI5/abap2UI5)
  - The migration is a no-op for current deployments
  - It remains only for building from older webapp states that predate the removal
  - The block can be deleted once main's webapp is synced past the routing removal

- **README.md documentation**: 
  - Simplified the manifest.json change description to focus only on the required version updates
  - Added a detailed note explaining that routing migration is a transitional safeguard
  - Clarified that schema v2 rejection of v1-style routing options only applies to legacy states
  - Noted that the migration is a no-op for current deployments and can be removed in the future

## Implementation Details
No functional code changes were made—this is purely a documentation update to prevent confusion about whether the routing migration is a required step or a legacy compatibility measure.

https://claude.ai/code/session_012E4cH2r3TKaP57cd3vjEEY