### PR TITLE
Rename build_custom workflow to build_rename

### DIFF
--- a/.github/bsp_rename/README.md
+++ b/.github/bsp_rename/README.md
@@ -6,10 +6,10 @@ way this repo ships as `Z2UI5` and `frontend-legacy-free` ships as `Z2UI5_V2`.
 
 Dependency-free Node script (Node 16+). Nothing to install.
 
-## Renamed branches via `build_custom` (recommended)
+## Renamed branches via `build_rename` (recommended)
 
-The easiest way to get a renamed install: run the **`build_custom`** GitHub
-workflow (Actions → build_custom → Run workflow), pick the base variant
+The easiest way to get a renamed install: run the **`build_rename`** GitHub
+workflow (Actions → build_rename → Run workflow), pick the base variant
 (`standard` or `standard_v2`) and enter the new BSP name (e.g. `ZMYUI5`, or
 a namespaced name like `/ABAPGIT/`, see below). It builds the base branch,
 applies this rename script to the generated `src` tree and pushes the result
@@ -67,7 +67,7 @@ Instead of a plain name you can rename into a **registered SAP namespace**:
 | `/ABAPGIT/MYAPP` | `/ABAPGIT/MYAPP` | `/ABAPGIT/MYAPP_CL_LP_HANDLER` |
 
 (The abapGit file-name spelling `#abapgit#myapp` is accepted as input too —
-that is also how the name is encoded in the `build_custom` branch name.)
+that is also how the name is encoded in the `build_rename` branch name.)
 
 Namespace max. 8 characters between the slashes, full BSP name max. 15
 characters including the slashes. What happens on top of a plain rename:

--- a/.github/build-branches.mjs
+++ b/.github/build-branches.mjs
@@ -17,7 +17,7 @@
 // z.B. standard_zmyui5 -> BSP ZMYUI5. <NAME> darf auch ein Namespace in
 // abapGit-Dateinamen-Schreibweise sein ("/" -> "#"): standard_#abapgit#
 // -> BSP /ABAPGIT/UI5, standard_#abapgit#x -> BSP /ABAPGIT/X (Details in
-// .github/bsp_rename). Der GitHub-Workflow build_custom baut und pusht
+// .github/bsp_rename). Der GitHub-Workflow build_rename baut und pusht
 // solche Branches on demand.
 //
 // Aufruf:  node .github/build-branches.mjs [branch ...]
@@ -64,7 +64,7 @@ const ABAPGIT_STANDARD = `﻿<?xml version="1.0" encoding="utf-8"?>
 `;
 
 function banner(branch) {
-  const workflow = BUILDERS[branch] ? `build_${branch}` : "build_custom";
+  const workflow = BUILDERS[branch] ? `build_${branch}` : "build_rename";
   return `> ⚙️ **Generated branch \`${branch}\`** — built from [\`main\`](../../tree/main) by the ` +
     "`" + workflow + "` workflow. Do not commit here, changes belong into `main`.\n\n";
 }

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -5,7 +5,7 @@ name: build_branch
 # (ohne inhaltliche Aenderung wird nichts gepusht). Der main-Commit wird als
 # zweiter Parent mitgefuehrt, damit GitHub den Branch als "ahead" statt
 # "behind" gegenueber main anzeigt. Aufgerufen von den vier
-# build_<branch>-Workflows sowie von build_custom (umbenannte BSP-Varianten
+# build_<branch>-Workflows sowie von build_rename (umbenannte BSP-Varianten
 # standard_<name> / standard_v2_<name>).
 
 on:
@@ -26,8 +26,8 @@ jobs:
     env:
       BRANCH: ${{ inputs.branch }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: 20
     - run: npm ci

--- a/.github/workflows/build_rename.yaml
+++ b/.github/workflows/build_rename.yaml
@@ -1,4 +1,4 @@
-name: build_custom
+name: build_rename
 
 # Baut eine umbenannte BSP-Variante (Parallelinstallation im selben SAP-System,
 # siehe .github/bsp_rename) und pusht sie auf den Branch <base>_<bsp-name>,
@@ -72,7 +72,7 @@ jobs:
         echo "branch=$branch" >> "$GITHUB_OUTPUT"
         echo "Baue Branch: $branch"
 
-  build_custom:
+  build_rename:
     needs: prepare
     uses: ./.github/workflows/build_branch.yaml
     with:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains an abap2UI5 frontend artefacts service. For more inform
 
 #### Renaming
 
-Need the BSP under a **different name** (e.g. a second copy in the same system)? Run the [`build_custom` workflow](https://github.com/abap2UI5/frontend/actions/workflows/build_custom.yaml) with a base variant and the new BSP name — plain (`ZMYUI5`) or in a registered namespace (`/ABAPGIT/` → BSP `/ABAPGIT/UI5`, handler `/ABAPGIT/CL_LP_HANDLER`) — it generates and pushes a branch `standard_<name>` / `standard_v2_<name>` with the whole deployment identity (BSP, SICF nodes, handler class) renamed. Details in [`.github/bsp_rename`](.github/bsp_rename).
+Need the BSP under a **different name** (e.g. a second copy in the same system)? Run the [`build_rename` workflow](https://github.com/abap2UI5/frontend/actions/workflows/build_rename.yaml) with a base variant and the new BSP name — plain (`ZMYUI5`) or in a registered namespace (`/ABAPGIT/` → BSP `/ABAPGIT/UI5`, handler `/ABAPGIT/CL_LP_HANDLER`) — it generates and pushes a branch `standard_<name>` / `standard_v2_<name>` with the whole deployment identity (BSP, SICF nodes, handler class) renamed. Details in [`.github/bsp_rename`](.github/bsp_rename).
 
 #### Issues
 For bug reports or feature requests, please open an issue in the [abap2UI5 repository.](https://github.com/abap2UI5/abap2UI5/issues)


### PR DESCRIPTION
## Summary
Rename the `build_custom` GitHub workflow to `build_rename` to better reflect its purpose of creating renamed BSP variants for parallel installation in the same SAP system.

## Key Changes
- Renamed workflow file from `build_custom.yaml` to `build_rename.yaml`
- Updated workflow name from `build_custom` to `build_rename` in the workflow definition
- Updated job name from `build_custom` to `build_rename` within the workflow
- Updated all documentation and code references to use `build_rename` instead of `build_custom`:
  - `.github/bsp_rename/README.md` - workflow references and instructions
  - `.github/workflows/build_branch.yaml` - workflow comments and action versions (v4→v5)
  - `.github/build-branches.mjs` - workflow name in banner generation logic
  - `README.md` - workflow link and documentation
- Updated GitHub Actions to latest versions (checkout@v4→v5, setup-node@v4→v5)

## Implementation Details
The rename is consistent across all references including:
- Workflow configuration and job definitions
- User-facing documentation and instructions
- Internal code comments and logic
- GitHub Actions workflow links

This change improves clarity by using a more descriptive name that accurately conveys the workflow's function of renaming BSP variants.

https://claude.ai/code/session_01JKe7rkdtsbeLhn4rm1STJ5