### PR TITLE
ci: serialize branch builds, add caching, monthly safety net and failure reporting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Keep the npm dependency tree and the GitHub Actions pinned versions
+# up to date and covered by security alerts.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      abaplint:
+        patterns:
+          - "@abaplint/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -30,6 +30,7 @@ jobs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
+        cache: 'npm'
     - run: npm ci
 
     # ABAP-Check der Cloud-Artefakte (abap/cloud), wie bisher ABAP_CLOUD

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  issues: write  # to report failed scheduled runs
 
 jobs:
   build:
@@ -64,3 +65,7 @@ jobs:
         commit=$(git commit-tree "$tree" ${parent:+-p "$parent"} -p "$GITHUB_SHA" -m "build: $b from $GITHUB_SHA")
         git push origin "$commit:refs/heads/$b"
         echo "$b: $commit gepusht"
+
+    - name: Report scheduled failure as issue
+      if: failure() && github.event_name == 'schedule'
+      uses: abap2UI5/abap2UI5/.github/actions/report-scheduled-failure@main

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm ci
 

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -26,10 +26,10 @@ jobs:
     env:
       BRANCH: ${{ inputs.branch }}
     steps:
-    - uses: actions/checkout@v5
-    - uses: actions/setup-node@v5
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 20
+        node-version: '20'
     - run: npm ci
 
     # ABAP-Check der Cloud-Artefakte (abap/cloud), wie bisher ABAP_CLOUD

--- a/.github/workflows/build_cloud.yaml
+++ b/.github/workflows/build_cloud.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  issues: write  # to report failed scheduled runs
 
 concurrency:
   group: build_cloud

--- a/.github/workflows/build_cloud.yaml
+++ b/.github/workflows/build_cloud.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # monthly safety net in case a create_frontend push is lost
+  schedule:
+    - cron: '0 5 1 * *'
 
 permissions:
   contents: write

--- a/.github/workflows/build_cloud.yaml
+++ b/.github/workflows/build_cloud.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: build_cloud
+  cancel-in-progress: false
+
 jobs:
   build_cloud:
     uses: ./.github/workflows/build_branch.yaml

--- a/.github/workflows/build_cloud_v2.yaml
+++ b/.github/workflows/build_cloud_v2.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # monthly safety net in case a create_frontend push is lost
+  schedule:
+    - cron: '0 5 1 * *'
 
 permissions:
   contents: write

--- a/.github/workflows/build_cloud_v2.yaml
+++ b/.github/workflows/build_cloud_v2.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: build_cloud_v2
+  cancel-in-progress: false
+
 jobs:
   build_cloud_v2:
     uses: ./.github/workflows/build_branch.yaml

--- a/.github/workflows/build_cloud_v2.yaml
+++ b/.github/workflows/build_cloud_v2.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  issues: write  # to report failed scheduled runs
 
 concurrency:
   group: build_cloud_v2

--- a/.github/workflows/build_rename.yaml
+++ b/.github/workflows/build_rename.yaml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: write
+  issues: write  # to report failed scheduled runs
 
 jobs:
   # Branch-Namen ableiten und Eingabe validieren, bevor gebaut wird

--- a/.github/workflows/build_standard.yaml
+++ b/.github/workflows/build_standard.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # monthly safety net in case a create_frontend push is lost
+  schedule:
+    - cron: '0 5 1 * *'
 
 permissions:
   contents: write

--- a/.github/workflows/build_standard.yaml
+++ b/.github/workflows/build_standard.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  issues: write  # to report failed scheduled runs
 
 concurrency:
   group: build_standard

--- a/.github/workflows/build_standard.yaml
+++ b/.github/workflows/build_standard.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: build_standard
+  cancel-in-progress: false
+
 jobs:
   build_standard:
     uses: ./.github/workflows/build_branch.yaml

--- a/.github/workflows/build_standard_v2.yaml
+++ b/.github/workflows/build_standard_v2.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: build_standard_v2
+  cancel-in-progress: false
+
 jobs:
   build_standard_v2:
     uses: ./.github/workflows/build_branch.yaml

--- a/.github/workflows/build_standard_v2.yaml
+++ b/.github/workflows/build_standard_v2.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # monthly safety net in case a create_frontend push is lost
+  schedule:
+    - cron: '0 5 1 * *'
 
 permissions:
   contents: write

--- a/.github/workflows/build_standard_v2.yaml
+++ b/.github/workflows/build_standard_v2.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  issues: write  # to report failed scheduled runs
 
 concurrency:
   group: build_standard_v2


### PR DESCRIPTION
## Why

Cross-repo CI/CD review — hardening and consistency for the branch-build pipeline:

- **Concurrency:** each `build_*` caller gets a fixed concurrency group (`cancel-in-progress: false`) so two quick pushes to main cannot race on the force-pushed output branches.
- **Safety net:** the four `build_*` callers additionally run on a monthly cron, so a lost `create_frontend` push from abap2UI5 is eventually caught up (`build_branch` skips the push when nothing changed, so quiet months cost one lint run and no commit).
- **Failure reporting:** `build_branch` reports failed scheduled runs as an issue via the shared `report-scheduled-failure` action from abap2UI5/abap2UI5; all callers grant `issues: write`.
- **Consistency:** SHA-pinned checkout/setup-node (abap2UI5 convention for pushing workflows), npm caching, Node 20 (maintenance ended April 2026) → 22, dependabot for npm and github-actions.

## Verification

`npm ci` and `npx abaplint` (0 issues) verified locally under Node 22.22.2. All workflow files parse as valid YAML.

**Merge order:** merge after the abap2UI5 PR (abap2UI5/abap2UI5#2405) — the cross-repo failure-report action is resolved at job start, so `build_*` runs fail until it exists on abap2UI5 `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GerBGPsdTGNSbztfoU358

---
_Generated by [Claude Code](https://claude.ai/code/session_014GerBGPsdTGNSbztfoU358)_